### PR TITLE
Use gettext and gettext_lazy instead of their deprecated aliases

### DIFF
--- a/docs/dashboard_custom.rst
+++ b/docs/dashboard_custom.rst
@@ -21,7 +21,7 @@ Set Up Custom Dashboard
 
    .. code-block:: python
 
-      from django.utils.translation import ugettext_lazy as _
+      from django.utils.translation import gettext_lazy as _
       from jet.dashboard import modules
       from jet.dashboard.dashboard import Dashboard, AppIndexDashboard
 

--- a/docs/dashboard_modules.rst
+++ b/docs/dashboard_modules.rst
@@ -85,7 +85,7 @@ Usage Example
 -------------
    .. code-block:: python
 
-     from django.utils.translation import ugettext_lazy as _
+     from django.utils.translation import gettext_lazy as _
      from jet.dashboard.dashboard import Dashboard, AppIndexDashboard
      from jet.dashboard.dashboard_modules import google_analytics
 
@@ -137,7 +137,7 @@ Usage Example
 -------------
    .. code-block:: python
 
-     from django.utils.translation import ugettext_lazy as _
+     from django.utils.translation import gettext_lazy as _
      from jet.dashboard.dashboard import Dashboard, AppIndexDashboard
      from jet.dashboard.dashboard_modules import yandex_metrika
 

--- a/jet/dashboard/dashboard.py
+++ b/jet/dashboard/dashboard.py
@@ -7,7 +7,7 @@ except ImportError: # Django 1.11
 from django.template.loader import render_to_string
 from jet.dashboard import modules
 from jet.dashboard.models import UserDashboardModule
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from jet.ordered_set import OrderedSet
 from jet.utils import get_admin_site_name, context_to_dict
 
@@ -65,7 +65,7 @@ class Dashboard(object):
 
         .. code-block:: python
 
-            from django.utils.translation import ugettext_lazy as _
+            from django.utils.translation import gettext_lazy as _
             from jet.dashboard import modules
             from jet.dashboard.dashboard import Dashboard, AppIndexDashboard
 

--- a/jet/dashboard/dashboard_modules/google_analytics.py
+++ b/jet/dashboard/dashboard_modules/google_analytics.py
@@ -16,7 +16,7 @@ from googleapiclient.discovery import build
 import httplib2
 from jet.dashboard.modules import DashboardModule
 from oauth2client.client import flow_from_clientsecrets, OAuth2Credentials, AccessTokenRefreshError, Storage
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.conf import settings
 from django.utils.encoding import force_text
 

--- a/jet/dashboard/dashboard_modules/google_analytics_views.py
+++ b/jet/dashboard/dashboard_modules/google_analytics_views.py
@@ -12,7 +12,7 @@ from jet.dashboard.models import UserDashboardModule
 from jet.dashboard import dashboard
 from django.http import HttpResponse
 from oauth2client.client import FlowExchangeError
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 def google_analytics_grant_view(request, pk):

--- a/jet/dashboard/dashboard_modules/yandex_metrika.py
+++ b/jet/dashboard/dashboard_modules/yandex_metrika.py
@@ -13,7 +13,7 @@ from django.utils.html import format_html
 from django.utils.safestring import mark_safe
 from django.utils.text import capfirst
 from jet.dashboard.modules import DashboardModule
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.conf import settings
 from django.utils.encoding import force_text
 

--- a/jet/dashboard/dashboard_modules/yandex_metrika_views.py
+++ b/jet/dashboard/dashboard_modules/yandex_metrika_views.py
@@ -10,7 +10,7 @@ from django.shortcuts import redirect
 from jet.dashboard.dashboard_modules.yandex_metrika import YandexMetrikaClient
 from jet.dashboard.models import UserDashboardModule
 from jet.dashboard import dashboard
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 def yandex_metrika_grant_view(request, pk):

--- a/jet/dashboard/models.py
+++ b/jet/dashboard/models.py
@@ -2,7 +2,7 @@ from importlib import import_module
 import json
 from django.db import models
 from six import python_2_unicode_compatible
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from jet.utils import LazyDateTimeEncoder
 
 

--- a/jet/dashboard/modules.py
+++ b/jet/dashboard/modules.py
@@ -3,7 +3,7 @@ from django import forms
 from django.contrib.admin.models import LogEntry
 from django.db.models import Q
 from django.template.loader import render_to_string
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from jet.utils import get_app_list, LazyDateTimeEncoder, context_to_dict
 import datetime
 
@@ -177,7 +177,7 @@ class LinkList(DashboardModule):
 
     .. code-block:: python
 
-        from django.utils.translation import ugettext_lazy as _
+        from django.utils.translation import gettext_lazy as _
         from jet.dashboard import modules
         from jet.dashboard.dashboard import Dashboard, AppIndexDashboard
 
@@ -278,7 +278,7 @@ class AppList(DashboardModule):
 
     .. code-block:: python
 
-        from django.utils.translation import ugettext_lazy as _
+        from django.utils.translation import gettext_lazy as _
         from jet.dashboard import modules
         from jet.dashboard.dashboard import Dashboard, AppIndexDashboard
 
@@ -351,7 +351,7 @@ class ModelList(DashboardModule):
 
     .. code-block:: python
 
-        from django.utils.translation import ugettext_lazy as _
+        from django.utils.translation import gettext_lazy as _
         from jet.dashboard import modules
         from jet.dashboard.dashboard import Dashboard, AppIndexDashboard
 
@@ -425,7 +425,7 @@ class RecentActions(DashboardModule):
 
     .. code-block:: python
 
-        from django.utils.translation import ugettext_lazy as _
+        from django.utils.translation import gettext_lazy as _
         from jet.dashboard import modules
         from jet.dashboard.dashboard import Dashboard, AppIndexDashboard
 
@@ -533,7 +533,7 @@ class Feed(DashboardModule):
 
     .. code-block:: python
 
-        from django.utils.translation import ugettext_lazy as _
+        from django.utils.translation import gettext_lazy as _
         from jet.dashboard import modules
         from jet.dashboard.dashboard import Dashboard, AppIndexDashboard
 

--- a/jet/dashboard/views.py
+++ b/jet/dashboard/views.py
@@ -13,7 +13,7 @@ from jet.dashboard.forms import UpdateDashboardModulesForm, AddUserDashboardModu
 from jet.dashboard.models import UserDashboardModule
 from jet.utils import JsonResponse, get_app_list, SuccessMessageMixin, user_is_authenticated
 from django.views.generic import UpdateView
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class UpdateDashboardModuleView(SuccessMessageMixin, UpdateView):

--- a/jet/filters.py
+++ b/jet/filters.py
@@ -54,7 +54,7 @@ try:
     from django import forms
     from django.contrib.admin.widgets import AdminDateWidget
     from rangefilter.filter import DateRangeFilter as OriginalDateRangeFilter
-    from django.utils.translation import ugettext as _
+    from django.utils.translation import gettext as _
 
 
     class DateRangeFilter(OriginalDateRangeFilter):

--- a/jet/models.py
+++ b/jet/models.py
@@ -1,7 +1,7 @@
 from django.db import models
 from django.utils import timezone
 from six import python_2_unicode_compatible
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 @python_2_unicode_compatible

--- a/jet/utils.py
+++ b/jet/utils.py
@@ -27,7 +27,7 @@ from django.utils.encoding import force_text
 from django.utils.functional import Promise
 from django.contrib.admin.options import IncorrectLookupParameters
 from django.contrib import admin
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.utils.text import slugify
 
 try:


### PR DESCRIPTION
The `ugettext` and `ugettext_lazy` were aliases for the corresponding `gettext*` functions and have been removed in Django 4.0+.